### PR TITLE
Fixed Bug in relayer-config

### DIFF
--- a/doc/relayer-config.md
+++ b/doc/relayer-config.md
@@ -431,7 +431,7 @@ paths:
         src:
             chain-id: uni-6
             client-id: 07-tendermint-115
-            connection-id: connection-120
+            connection-id: connection-124
         dst:
             chain-id: elgafar-1
             client-id: 07-tendermint-211


### PR DESCRIPTION
The connection was set wrong. According to a node IBC query (I also tested self relay) this are the settings:

 client_id: 07-tendermint-115
  counterparty:
    client_id: 07-tendermint-211
    connection_id: connection-200
    prefix:
      key_prefix: aWJj
  delay_period: "0"
  id: connection-124
  state: STATE_OPEN
  versions:
  - features:
    - ORDER_ORDERED
    - ORDER_UNORDERED identifier: "1"